### PR TITLE
Support build action by adding the `--action` option in the command.

### DIFF
--- a/Sources/CreateXCFramework/BuildSetting.swift
+++ b/Sources/CreateXCFramework/BuildSetting.swift
@@ -16,7 +16,7 @@ struct BuildSetting: ExpressibleByArgument {
     let value: String
 
     init?(argument: String) {
-        let components = argument.components(separatedBy: "=")
+        let components = argument.split(separator: "=", maxSplits: 1)
         guard components.count == 2 else { return nil }
         self.name = components[0].trimmingCharacters(in: .whitespacesAndNewlines)
         self.value = components[1].trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -25,6 +25,9 @@ extension Command {
         @Option(help: ArgumentHelp("Build with a specific configuration", valueName: "debug|release"))
         var configuration = PackageModel.BuildConfiguration.release
 
+        @Option(help: ArgumentHelp("Action used to create artifact", valueName: "archive|build"))
+        var action: XcodeBuildAction = .archive
+
         @Flag(inversion: .prefixedNo, help: "Whether to clean before we build")
         var clean = true
 

--- a/Sources/CreateXCFramework/XcodeBuildAction.swift
+++ b/Sources/CreateXCFramework/XcodeBuildAction.swift
@@ -1,0 +1,13 @@
+//
+//  XcodeBuildAction.swift
+//  swift-create-xcframework
+//
+//  Created by Hanley Lee on 2024/6/1.
+//
+
+import ArgumentParser
+
+enum XcodeBuildAction: String, ExpressibleByArgument {
+    case build
+    case archive
+}


### PR DESCRIPTION
Sometimes we want to use `xcodebuild build ...` instead `xcodebuild archive ...`, because artifacts generated by `xcodebuild build ...` contain more debug information. For example: [`.swiftsourcefile`](https://forums.swift.org/t/proposal-emitting-source-information-file-during-compilation/28794) will only be generated when invoked by the `xcodebuild build ...` command.

The xcframework of [Alamofire](https://github.com/Alamofire/Alamofire) generated by the `swift-create-xcframework --platform ios --action build --xc-setting OTHER_SWIFT_FLAGS="-debug-prefix-map $PWD=." Alamofire` command are as below:

```txt
Alamofire.xcframework
├── Info.plist
├── ios-arm64
│   ├── Alamofire.framework
│   │   ├── Alamofire
│   │   ├── Headers
│   │   │   └── Alamofire-Swift.h
│   │   ├── Info.plist
│   │   └── Modules
│   │       └── Alamofire.swiftmodule
│   │           ├── Project
│   │           │   └── arm64-apple-ios.swiftsourceinfo                  <============= Look here!!!
│   │           ├── arm64-apple-ios.abi.json
│   │           ├── arm64-apple-ios.private.swiftinterface
│   │           ├── arm64-apple-ios.swiftdoc
│   │           └── arm64-apple-ios.swiftinterface
│   └── dSYMs
│       └── Alamofire.framework.dSYM
│           └── Contents
│               ├── Info.plist
│               └── Resources
│                   ├── DWARF
│                   └── Relocations
└── ios-arm64_x86_64-simulator
    ├── Alamofire.framework
    │   ├── Alamofire
    │   ├── Headers
    │   │   └── Alamofire-Swift.h
    │   ├── Info.plist
    │   ├── Modules
    │   │   └── Alamofire.swiftmodule
    │   │       ├── Project
    │   │       │   ├── arm64-apple-ios-simulator.swiftsourceinfo
    │   │       │   └── x86_64-apple-ios-simulator.swiftsourceinfo
    │   │       ├── arm64-apple-ios-simulator.abi.json
    │   │       ├── arm64-apple-ios-simulator.private.swiftinterface
    │   │       ├── arm64-apple-ios-simulator.swiftdoc
    │   │       ├── arm64-apple-ios-simulator.swiftinterface
    │   │       ├── x86_64-apple-ios-simulator.abi.json
    │   │       ├── x86_64-apple-ios-simulator.private.swiftinterface
    │   │       ├── x86_64-apple-ios-simulator.swiftdoc
    │   │       └── x86_64-apple-ios-simulator.swiftinterface
    │   └── _CodeSignature
    │       └── CodeResources
    └── dSYMs
        └── Alamofire.framework.dSYM
            └── Contents
                ├── Info.plist
                └── Resources
                    ├── DWARF
                    └── Relocations

26 directories, 25 files
```

Output of `swift-create-xcframework --platform ios --action archive --xc-setting OTHER_SWIFT_FLAGS="-debug-prefix-map $PWD=." Alamofire` command are as below(no `.swiftsourceinfo` file):

```txt
Alamofire.xcframework
├── Info.plist
├── ios-arm64
│   ├── Alamofire.framework
│   │   ├── Alamofire
│   │   ├── Headers
│   │   │   └── Alamofire-Swift.h
│   │   ├── Info.plist
│   │   └── Modules
│   │       └── Alamofire.swiftmodule
│   │           ├── arm64-apple-ios.abi.json
│   │           ├── arm64-apple-ios.private.swiftinterface
│   │           ├── arm64-apple-ios.swiftdoc
│   │           └── arm64-apple-ios.swiftinterface
│   └── dSYMs
│       └── Alamofire.framework.dSYM
│           └── Contents
│               ├── Info.plist
│               └── Resources
│                   ├── DWARF
│                   └── Relocations
└── ios-arm64_x86_64-simulator
    ├── Alamofire.framework
    │   ├── Alamofire
    │   ├── Headers
    │   │   └── Alamofire-Swift.h
    │   ├── Info.plist
    │   ├── Modules
    │   │   └── Alamofire.swiftmodule
    │   │       ├── arm64-apple-ios-simulator.abi.json
    │   │       ├── arm64-apple-ios-simulator.private.swiftinterface
    │   │       ├── arm64-apple-ios-simulator.swiftdoc
    │   │       ├── arm64-apple-ios-simulator.swiftinterface
    │   │       ├── x86_64-apple-ios-simulator.abi.json
    │   │       ├── x86_64-apple-ios-simulator.private.swiftinterface
    │   │       ├── x86_64-apple-ios-simulator.swiftdoc
    │   │       └── x86_64-apple-ios-simulator.swiftinterface
    │   └── _CodeSignature
    │       └── CodeResources
    └── dSYMs
        └── Alamofire.framework.dSYM
            └── Contents
                ├── Info.plist
                └── Resources
                    ├── DWARF
                    └── Relocations

24 directories, 22 files
```

The `.swiftsourceinfo` file can be used to jump to the definition in the source code. Our team usually compiles third-party modules from source code to XCFramework to reduce compile time, and we also want to retain the ability to jump source code by clicking a property or class. Therefore we implemented `--action` option to configure the action used by `xcodebuild` inside `swift-create-xcframework`