### PR TITLE
feat: add support for Swift 5.10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-asn1.git",
         "state": {
           "branch": null,
-          "revision": "805deae27a7506dcad043604c00a9dc52d465dcb",
-          "version": "0.7.0"
+          "revision": "df5d2fcd22e3f480e3ef85bf23e277a4a0ef524d",
+          "version": "1.2.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-certificates.git",
         "state": {
           "branch": null,
-          "revision": "35a7df2d9d71c401a47de9be2e3de629a01370c2",
-          "version": "0.4.1"
+          "revision": "83640c8097acaec17c9835a083e89678cb0f2b66",
+          "version": "1.3.0"
         }
       },
       {
@@ -42,16 +42,16 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "33a20e650c33f6d72d822d558333f2085effa3dc",
-          "version": "2.5.0"
+          "revision": "629f0b679d0fd0a6ae823d7f750b9ab032c00b80",
+          "version": "3.0.0"
         }
       },
       {
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.9",
-          "revision": "1b2b851ae4718caffa5f18fd1861bc0ddd1791a3",
+          "branch": "release/5.10",
+          "revision": "b461fd4fc51be8e1f2a3f4a2184b664b8846b46f",
           "version": null
         }
       },
@@ -59,8 +59,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.9",
-          "revision": "d73a305d6e5a82e4bf3bf1727da3d1376e87efab",
+          "branch": "release/5.10",
+          "revision": "fd7c2e0d9279edd023ced6b0a590f8407f5472f9",
           "version": null
         }
       },
@@ -68,8 +68,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.9",
-          "revision": "732d5406df67b64d266c5689454cf52aecbb4d57",
+          "branch": "release/5.10",
+          "revision": "b5f8ad931b7a40b81f64765fa08c2751164759b4",
           "version": null
         }
       },
@@ -86,8 +86,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.9",
-          "revision": "5665fc7641ce1a971ad06faaa476862b222ef44b",
+          "branch": "release/5.10",
+          "revision": "90bdc2a157ebacc5d3de0c83e085d05d22ca5fa0",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,23 @@ let dependencies: [Package.Dependency]
 let versionedTargets: [Target]
 let versionedDependencies: [Target.Dependency]
 
-#if swift(>=5.9)
+#if swift(>=5.10)
+dependencies = [
+  .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.3"),
+  .package(url: "https://github.com/apple/swift-package-manager.git", branch: "release/5.10"),
+//  .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "release/5.10"),
+]
+versionedTargets = [
+    .target(
+        name: "Xcodeproj",
+        dependencies: [
+            .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+//            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        ]
+    )
+]
+versionedDependencies = ["Xcodeproj"]
+#elseif swift(>=5.9)
 dependencies = [
     .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("1.2.3")),
     .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.9")),
@@ -58,7 +74,11 @@ versionedDependencies = []
 #endif
 
 let platforms: [SupportedPlatform]
-#if swift(>=5.6)
+#if swift(>=5.10)
+platforms = [
+    .macOS(.v12),
+]
+#elseif swift(>=5.6)
 platforms = [
     .macOS(.v11),
 ]
@@ -83,8 +103,8 @@ let package = Package(
     targets: versionedTargets + [
         .target(name: "CreateXCFramework", dependencies: versionedDependencies + [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            .product(name: "SwiftPM-auto", package: "SwiftPM"),
-            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+            .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+//            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         ]),
         .testTarget(name: "CreateXCFrameworkTests", dependencies: [ "CreateXCFramework" ]),
     ],

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -84,13 +84,13 @@ struct PackageInfo {
         self.rootDirectory = Foundation.URL(fileURLWithPath: options.packagePath, isDirectory: true).absoluteURL
         self.buildDirectory = self.rootDirectory.appendingPathComponent(options.buildPath, isDirectory: true).absoluteURL
 
-        let root = try AbsolutePath(validating: self.rootDirectory.path)
+      let root = try TSCBasic.AbsolutePath(validating: self.rootDirectory.path)
 
         self.toolchain = try UserToolchain(destination: try .hostDestination())
 
         #if swift(>=5.7)
         let loader = ManifestLoader(toolchain: self.toolchain)
-        self.workspace = try Workspace(forRootPackage: root, customManifestLoader: loader)
+        self.workspace = try Workspace(forRootPackage: root.absPath, customManifestLoader: loader)
         #elseif swift(>=5.6)
         let resources = ToolchainConfiguration(swiftCompilerPath: self.toolchain.swiftCompilerPath)
         let loader = ManifestLoader(toolchain: resources)
@@ -106,12 +106,12 @@ struct PackageInfo {
         #endif
 
         #if swift(>=5.6)
-        self.graph = try workspace.loadPackageGraph(rootPath: root, observabilityScope: self.observabilitySystem.topScope)
+        self.graph = try workspace.loadPackageGraph(rootPath: root.absPath, observabilityScope: self.observabilitySystem.topScope)
         let workspace = self.workspace
         let scope = observabilitySystem.topScope
         self.manifest = try tsc_await {
             workspace.loadRootManifest(
-                at: root,
+                at: root.absPath,
                 observabilityScope: scope,
                 completion: $0
             )

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -86,7 +86,7 @@ struct ProjectGenerator {
                 xcconfigOverrides: (self.package.overridesXcconfig?.path).flatMap { try AbsolutePath(validating: $0) },
                 useLegacySchemeGenerator: true
             ),
-            fileSystem: localFileSystem,
+            fileSystem: reallyLocalFileSystem,
             observabilityScope: self.package.observabilitySystem.topScope
         )
 #else

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -113,8 +113,8 @@ struct Zipper {
     }
 
     #if swift(>=5.7)
-    private func checksum(forBinaryArtifactAt path: AbsolutePath) throws -> String {
-        let fileSystem = localFileSystem
+  private func checksum(forBinaryArtifactAt path: TSCBasic.AbsolutePath) throws -> String {
+    let fileSystem = TSCBasic.localFileSystem
         let checksumAlgorithm = SHA256()
         let archiver = ZipArchiver(fileSystem: fileSystem)
 

--- a/Sources/Xcodeproj/Converters.swift
+++ b/Sources/Xcodeproj/Converters.swift
@@ -1,0 +1,14 @@
+import Foundation
+import TSCBasic
+import Basics
+
+//public typealias AbsolutePath = TSCBasic.AbsolutePath
+public var reallyLocalFileSystem = TSCBasic.localFileSystem
+
+extension TSCBasic.AbsolutePath {
+  public var absPath: Basics.AbsolutePath { try! Basics.AbsolutePath(validating: self.pathString) }
+}
+
+extension Basics.AbsolutePath {
+  public var absPath: TSCBasic.AbsolutePath { try! TSCBasic.AbsolutePath(validating: self.pathString) }
+}

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -44,7 +44,7 @@ public final class SchemesGenerator {
 
     private let graph: PackageGraph
     private let container: String
-    private let schemesDir: AbsolutePath
+  private let schemesDir: AbsolutePath
     private let isCodeCoverageEnabled: Bool
     private let fs: FileSystem
 
@@ -208,12 +208,12 @@ public final class SchemesGenerator {
 
             """
 
-        let file = try AbsolutePath(validating: scheme.filename, relativeTo: schemesDir)
+      let file = try AbsolutePath(validating: scheme.filename, relativeTo: schemesDir)
         try fs.writeFileContents(file, bytes: stream.bytes)
     }
 
     private func disableSchemeAutoCreation() throws {
-        let workspacePath = try AbsolutePath(validating: "../../project.xcworkspace", relativeTo: schemesDir)
+      let workspacePath = try AbsolutePath(validating: "../../project.xcworkspace", relativeTo: schemesDir)
 
         // Write the settings file to disable automatic scheme creation.
         var stream = BufferedOutputByteStream()
@@ -227,12 +227,12 @@ public final class SchemesGenerator {
             </dict>
             </plist>
             """
-        let settingsPlist = try AbsolutePath(validating: "xcshareddata/WorkspaceSettings.xcsettings", relativeTo: workspacePath)
+      let settingsPlist = try AbsolutePath(validating: "xcshareddata/WorkspaceSettings.xcsettings", relativeTo: workspacePath)
         try fs.createDirectory(settingsPlist.parentDirectory, recursive: true)
         try fs.writeFileContents(settingsPlist, bytes: stream.bytes)
 
         // Write workspace contents file.
-        let contentsFile = try AbsolutePath(validating: "contents.xcworkspacedata", relativeTo: workspacePath)
+      let contentsFile = try AbsolutePath(validating: "contents.xcworkspacedata", relativeTo: workspacePath)
         stream = BufferedOutputByteStream()
         stream <<< """
             <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The main issue is that SwiftPM depends on TSCBasic but declares types that are the same as those in TSCBasic, like AbsolutePath, which creates conflicts.

The fix is to add a converter file that contain helpers for the type conversion.

This PR is a prototype.