### PR TITLE
Add an option to skip project generation for binary targets (vs throwing an error)

### DIFF
--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -77,6 +77,8 @@ extension Command {
         @Flag(help: .hidden)
         var githubAction: Bool = false
 
+        @Flag(help: "Skip binary targets for project generation. Useful for creating and distributing a library from one Package.swift")
+        var skipBinaryTargets: Bool = false
 
         // MARK: - Targets
 

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -147,7 +147,7 @@ struct PackageInfo {
 
         // check the graph for binary targets
         let binary = self.graph.allTargets.filter { $0.type == .binary }
-        if binary.isEmpty == false {
+        if !options.skipBinaryTargets, binary.isEmpty == false {
             errors.append(.containsBinaryTargets(binary.map(\.name)))
         }
 

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -84,7 +84,8 @@ struct ProjectGenerator {
             extraFiles: [],
             options: XcodeprojOptions (
                 xcconfigOverrides: (self.package.overridesXcconfig?.path).flatMap { try AbsolutePath(validating: $0) },
-                useLegacySchemeGenerator: true
+                useLegacySchemeGenerator: true,
+                skipBinaryTargets: package.options.skipBinaryTargets
             ),
             fileSystem: localFileSystem,
             observabilityScope: self.package.observabilitySystem.topScope
@@ -97,7 +98,8 @@ struct ProjectGenerator {
             extraFiles: [],
             options: XcodeprojOptions (
                 xcconfigOverrides: (self.package.overridesXcconfig?.path).flatMap { AbsolutePath($0) },
-                useLegacySchemeGenerator: true
+                useLegacySchemeGenerator: true,
+                skipBinaryTargets: package.options.skipBinaryTargets
             ),
             diagnostics: self.package.diagnostics
         )

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -45,13 +45,16 @@ public struct XcodeprojOptions {
     /// Reference to manifest loader, if present.
     public var manifestLoader: ManifestLoader?
 
+    public var skipBinaryTargets: Bool
+
     public init(
         flags: PackageModel.BuildFlags = PackageModel.BuildFlags(),
         xcconfigOverrides: AbsolutePath? = nil,
         isCodeCoverageEnabled: Bool? = nil,
         useLegacySchemeGenerator: Bool? = nil,
         enableAutogeneration: Bool? = nil,
-        addExtraFiles: Bool? = nil
+        addExtraFiles: Bool? = nil,
+        skipBinaryTargets: Bool? = nil
     ) {
         self.flags = flags
         self.xcconfigOverrides = xcconfigOverrides
@@ -59,6 +62,7 @@ public struct XcodeprojOptions {
         self.useLegacySchemeGenerator = useLegacySchemeGenerator ?? false
         self.enableAutogeneration = enableAutogeneration ?? false
         self.addExtraFiles = addExtraFiles ?? true
+        self.skipBinaryTargets = skipBinaryTargets ?? false
     }
 }
 

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -396,7 +396,13 @@ public func xcodeProject(
             productType = .framework
         case .test:
             productType = .unitTest
-        case .systemModule, .binary, .plugin, .macro:
+        case .binary:
+            if options.skipBinaryTargets {
+                continue
+            } else {
+                fallthrough
+            }
+        case .systemModule, .plugin, .macro:
             throw InternalError("\(target.type) not supported")
         }
 


### PR DESCRIPTION
It is sometimes useful to provide both a source and precompiled version of the same product from the same Package.swift file. Unfortunately, we cannot use swift-create-xcframework to build for that case, as any binary targets added to the package will fail project generation with an error, even if they not needed for building the specified product.

This PR offers a simple workaround - the ability to skip adding binary targets if they are not needed for a build.