### PR TITLE
feat: add support for internal distribution flag in xcframework creation

### DIFF
--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -80,6 +80,9 @@ extension Command {
         @Flag(help: "Skip binary targets for project generation. Useful for creating and distributing a library from one Package.swift")
         var skipBinaryTargets: Bool = false
 
+        @Flag(help: "Specifies that the created xcframework contains information not suitable for public distribution.")
+        var allowInternalDistribution: Bool = false
+
         // MARK: - Targets
 
         @Argument(help: "An optional list of products (or targets) to build. Defaults to building all `.library` products")

--- a/Sources/CreateXCFramework/XcodeBuilder.swift
+++ b/Sources/CreateXCFramework/XcodeBuilder.swift
@@ -306,6 +306,10 @@ struct XcodeBuilder {
             return args
         }
 
+        if self.package.options.allowInternalDistribution {
+            command += [ "-allow-internal-distribution" ]
+        }
+
         // and the output
         command += [ "-output", outputPath.path ]
 


### PR DESCRIPTION
After building Factory xcframwork, I get some errors "Failed to build module 'Factory" when importing Factory in other project.  I find that if there is arm64-apple-ios.swiftmodule in `Factory.xcframework/ios-arm64/Factory.framework/Modules/Factory.swiftmodule` which can fix these errors, so I add this flag

This commit introduces a new `allowInternalDistribution` flag to the command options, enabling the creation of xcframeworks containing information not suitable for public distribution. The flag is passed to the xcodebuild command when set, ensuring the xcframework is built with the appropriate configuration.


